### PR TITLE
Clear the flag 'TKG_Slot.status.started' when a tkg stopped

### DIFF
--- a/js/tkg-slot.js
+++ b/js/tkg-slot.js
@@ -192,6 +192,7 @@
       var self = this;
       self.status.pause = true;
       clearInterval(self.timer);
+      self.status.started = false;
       self.setStatus();
       judgement();
     };


### PR DESCRIPTION
スロットを止めたときに started のフラグが降りるようにし、クリック数が 3 回に留まってしまう件を修正しました。試運転してみたところ、click_count++ に処理が遷移しているので大丈夫かと思いますが、いかがでしょうか…？
